### PR TITLE
Fix plot images

### DIFF
--- a/src/test.py
+++ b/src/test.py
@@ -3,7 +3,6 @@ from model.model import MobileHairNet
 import os
 from glob import glob
 import matplotlib.pyplot as plt
-from torchvision.utils import save_image
 
 
 class Tester:
@@ -50,13 +49,12 @@ class Tester:
                 mask = mask.to(self.device)
                 criterion = self.net(image)
 
-                subplot = fig.add_subplot(epoch + 1, 3, epoch + 1)
-                subplot.imshow(
-                    [image[0].cpu().numpy(), mask[0].cpu().numpy(), torch.argmax(criterion[0], 0).cpu().numpy()])
-                subplot.set_xticks([])
-                subplot.set_yticks([])
+                for idx, img in enumerate([image, mask, criterion]):
+                    subplot = fig.add_subplot(1, 3, idx + 1)
+                    subplot.imshow(img.cpu().numpy().transposse(1, 2, 0))
+                    subplot.set_xticks([])
+                    subplot.set_yticks([])
+
+                dir_name = os.path.join(self.test_dir, f"test_epoch{epoch}_step{step}.png")
+                plt.savefig(dir_name)
                 print('[*] Saved sample images')
-        dir_name = os.path.join(self.test_dir, "test.png")
-        plt.savefig(dir_name)
-
-

--- a/src/test.py
+++ b/src/test.py
@@ -49,7 +49,7 @@ class Tester:
                 mask = mask.to(self.device)
                 criterion = self.net(image)
 
-                for idx, img in enumerate([image, mask, criterion]):
+                for idx, img in enumerate([image[0], mask[0], criterion[0]]):
                     subplot = fig.add_subplot(1, 3, idx + 1)
                     subplot.imshow(img.cpu().numpy().transposse(1, 2, 0))
                     subplot.set_xticks([])


### PR DESCRIPTION
## Summary
- `imshow` does not work. because format of  `imshow` 's input  is wrong. correct format is [height, width, channels]  (now, you are using  torch's output  format [channels,  height, width])
  - doc: https://matplotlib.org/3.1.1/api/_as_gen/matplotlib.pyplot.imshow.html#matplotlib.pyplot.imshow

- I guess you want to overlay `images` and `mask`, `criterion`. it is better to plot each images and save that.